### PR TITLE
Add Agent Suite LangGraph career assistant project

### DIFF
--- a/agent_suite/.gitignore
+++ b/agent_suite/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+.playwright/

--- a/agent_suite/README.md
+++ b/agent_suite/README.md
@@ -1,0 +1,126 @@
+# Agent Suite – AI-Powered Career Assistant
+
+Agent Suite automates the end-to-end job and internship application pipeline using a LangGraph-powered multi-agent workflow. The project demonstrates how specialized AI agents can collaborate to research opportunities, tailor materials, communicate with recruiters, and track outcomes.
+
+## Key Features
+
+- **Profile Agent** – normalizes candidate data and generates embeddings for semantic search.
+- **Search Agent** – queries job sources (sample dataset, pluggable architecture) and ranks results using embedding similarity.
+- **JD Parser Agent** – converts job descriptions into structured JSON (skills, keywords, responsibilities).
+- **Resume Agent** – creates ATS-friendly resume variants per role via templating and scoring heuristics.
+- **Communications Agent** – drafts cover letters and recruiter emails with tone customization.
+- **Human-in-the-loop Node** – optional pause for manual edits before submission.
+- **Sender Agent** – dispatches emails (Gmail/SMTP ready interface) and logs submissions.
+- **Tracker Agent** – maintains an application dashboard with follow-up events.
+
+The workflow is orchestrated through LangGraph, enabling modular nodes, conditional routing, and asynchronous execution.
+
+## Architecture Overview
+
+```
+Profile Agent -> Search Agent -> JD Parser -> Resume Agent -> Comms Agent
+        -> Human Review -> Sender Agent -> Tracker Agent
+```
+
+Supporting services provide embeddings, job search abstractions, resume and communications templating, email sending, and tracking. The backend is exposed via FastAPI for integration with UIs or automation scripts.
+
+## Tech Stack
+
+- **Framework**: [LangGraph](https://github.com/langchain-ai/langgraph) for graph-based agent orchestration.
+- **Backend**: FastAPI with modular routers.
+- **Data & Storage**: SQLAlchemy models for PostgreSQL/pgvector, FAISS-ready embeddings, JSON sample datasets.
+- **File Generation**: Jinja2 templates (extendable to `python-docx` or `reportlab`).
+- **Email Integration**: Gmail/SMTP-ready abstraction with logging.
+- **Scraping**: Playwright + BeautifulSoup/selectolax placeholders (extend job search service).
+- **Observability Hooks**: Structlog logging, Prometheus/Sentry ready.
+
+## Project Layout
+
+```
+agent_suite/
+├── agent_suite/
+│   ├── agents/               # Agent implementations
+│   ├── api/                  # FastAPI app and routers
+│   ├── config/               # Typed settings management
+│   ├── data/                 # Sample datasets (jobs, templates)
+│   ├── db/                   # SQLAlchemy models and engine
+│   ├── services/             # Shared services (search, resume, comms, etc.)
+│   ├── templates/            # Jinja2 templates for resumes & emails
+│   └── workflows/            # LangGraph workflow definitions
+├── scripts/
+│   └── run_example.py        # Run the workflow end-to-end
+├── tests/
+│   └── test_workflow.py      # Pytest coverage for workflow paths
+└── pyproject.toml            # Dependencies and tooling
+```
+
+## Installation
+
+1. Ensure Python 3.11+ is installed.
+2. Install dependencies (Poetry recommended):
+
+```bash
+cd agent_suite
+poetry install
+# or: pip install -e .
+```
+
+3. Export any required API keys (e.g., `OPENAI_API_KEY`) if using hosted LLMs.
+
+## Running the Workflow
+
+### Command Line Example
+
+```
+poetry run python scripts/run_example.py
+```
+
+The script prints the final workflow state including submissions and dashboard events.
+
+### FastAPI Server
+
+```
+poetry run uvicorn agent_suite.api.main:app --reload
+```
+
+Invoke the `/workflow/run` endpoint with a JSON payload:
+
+```json
+{
+  "profile": {
+    "full_name": "Aditi Sharma",
+    "email": "aditi@example.com",
+    "education": ["B.Tech Computer Science – IIT Kanpur"],
+    "skills": ["Python", "Machine Learning", "LangChain", "FastAPI"],
+    "projects": [
+      {"name": "Autonomous Agent Research", "description": "...", "impact": "Improved matching accuracy by 25%"}
+    ],
+    "interests": ["AI Research", "Autonomous Agents"],
+    "preferences": {"keywords": ["AI", "research"], "locations": ["Kanpur, India", "Remote"], "remote": true}
+  },
+  "auto_send": true
+}
+```
+
+If `auto_send` is `false`, the workflow halts at the human review node and returns HTTP 202 to signal manual intervention before resuming.
+
+## Extending the System
+
+- **Job Sources**: Replace `services/job_search.py` with live scrapers (Playwright + BeautifulSoup/selectolax) and integrate API keys for LinkedIn/Indeed.
+- **Resume Generation**: Swap templating with `python-docx` or `reportlab` exporters, attach PDFs to emails.
+- **Communication Personalization**: Integrate LLM prompts via LangChain to generate richer emails and follow-up schedules.
+- **Sender Agent**: Connect Gmail API/OAuth credentials for real deliveries.
+- **Tracker**: Persist to PostgreSQL and visualize metrics via Grafana; feed Prometheus counters and Sentry breadcrumbs.
+- **Evaluation**: Compare ATS scores from baseline vs tailored resumes and conduct live testing on IIT Kanpur research openings.
+
+## Testing
+
+Run the automated tests with:
+
+```
+poetry run pytest
+```
+
+## License
+
+MIT License. See `pyproject.toml` for attribution details.

--- a/agent_suite/agent_suite/__init__.py
+++ b/agent_suite/agent_suite/__init__.py
@@ -1,0 +1,8 @@
+"""Agent Suite package providing multi-agent orchestration for job applications."""
+
+__all__ = [
+    "config",
+    "agents",
+    "services",
+    "workflows",
+]

--- a/agent_suite/agent_suite/agents/__init__.py
+++ b/agent_suite/agent_suite/agents/__init__.py
@@ -1,0 +1,23 @@
+"""Agent implementations for the Agent Suite workflow."""
+
+from .base import AgentContext, AgentResult, BaseAgent
+from .profile import ProfileAgent
+from .search import SearchAgent
+from .jd_parser import JobDescriptionParserAgent
+from .resume import ResumeAgent
+from .comms import CommunicationsAgent
+from .sender import SenderAgent
+from .tracker import TrackerAgent
+
+__all__ = [
+    "AgentContext",
+    "AgentResult",
+    "BaseAgent",
+    "ProfileAgent",
+    "SearchAgent",
+    "JobDescriptionParserAgent",
+    "ResumeAgent",
+    "CommunicationsAgent",
+    "SenderAgent",
+    "TrackerAgent",
+]

--- a/agent_suite/agent_suite/agents/base.py
+++ b/agent_suite/agent_suite/agents/base.py
@@ -1,0 +1,46 @@
+"""Base agent definitions used across the workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Generic, Optional, TypeVar
+
+from langchain_core.runnables import RunnableConfig
+
+
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
+
+
+@dataclass
+class AgentContext:
+    """Shared context passed between agents in the workflow."""
+
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    config: Optional[RunnableConfig] = None
+
+
+@dataclass
+class AgentResult(Generic[OutputT]):
+    """Standardized result returned by all agents."""
+
+    output: OutputT
+    context: AgentContext
+
+
+class BaseAgent(Generic[InputT, OutputT]):
+    """Base class providing lifecycle hooks for agents."""
+
+    name: str = "base-agent"
+
+    async def arun(self, data: InputT, context: AgentContext) -> AgentResult[OutputT]:
+        """Asynchronous entrypoint for agent execution."""
+
+        output = await self._arun(data, context)
+        return AgentResult(output=output, context=context)
+
+    async def _arun(self, data: InputT, context: AgentContext) -> OutputT:  # pragma: no cover - to override
+        raise NotImplementedError
+
+
+__all__ = ["AgentContext", "AgentResult", "BaseAgent"]

--- a/agent_suite/agent_suite/agents/comms.py
+++ b/agent_suite/agent_suite/agents/comms.py
@@ -1,0 +1,37 @@
+"""Agent that generates cover letters and recruiter emails."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from agent_suite.agents.base import AgentContext, BaseAgent
+from agent_suite.services import CommunicationsBuilder
+
+
+class CommunicationsAgent(BaseAgent[List[Dict[str, Any]], List[Dict[str, Any]]]):
+    """Produces personalized communications for each job."""
+
+    name = "communications-agent"
+
+    def __init__(self, builder: CommunicationsBuilder | None = None) -> None:
+        self._builder = builder or CommunicationsBuilder()
+
+    async def _arun(self, data: List[Dict[str, Any]], context: AgentContext) -> List[Dict[str, Any]]:
+        profile = context.metadata.get("profile", {})
+        comms_payloads: List[Dict[str, Any]] = []
+        for resume in data:
+            job = resume["job"]
+            communications = self._builder.build(profile, job)
+            payload = dict(resume)
+            payload.update(
+                {
+                    "cover_letter": communications.cover_letter,
+                    "recruiter_email": communications.recruiter_email,
+                }
+            )
+            comms_payloads.append(payload)
+        context.metadata["communications"] = comms_payloads
+        return comms_payloads
+
+
+__all__ = ["CommunicationsAgent"]

--- a/agent_suite/agent_suite/agents/jd_parser.py
+++ b/agent_suite/agent_suite/agents/jd_parser.py
@@ -1,0 +1,30 @@
+"""Agent that converts raw job descriptions into structured insights."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from agent_suite.agents.base import AgentContext, BaseAgent
+from agent_suite.services import JobDescriptionParser
+
+
+class JobDescriptionParserAgent(BaseAgent[List[Dict[str, Any]], List[Dict[str, Any]]]):
+    """Parses job descriptions to augment job postings."""
+
+    name = "jd-parser-agent"
+
+    def __init__(self, parser: JobDescriptionParser | None = None) -> None:
+        self._parser = parser or JobDescriptionParser()
+
+    async def _arun(self, data: List[Dict[str, Any]], context: AgentContext) -> List[Dict[str, Any]]:
+        parsed_jobs: List[Dict[str, Any]] = []
+        for job in data:
+            structured = self._parser.parse(job.get("description", ""))
+            enriched_job = dict(job)
+            enriched_job.setdefault("structured_data", {}).update(structured)
+            parsed_jobs.append(enriched_job)
+        context.metadata["parsed_jobs"] = parsed_jobs
+        return parsed_jobs
+
+
+__all__ = ["JobDescriptionParserAgent"]

--- a/agent_suite/agent_suite/agents/profile.py
+++ b/agent_suite/agent_suite/agents/profile.py
@@ -1,0 +1,41 @@
+"""Profile agent responsible for ingesting and normalizing user data."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from agent_suite.agents.base import AgentContext, BaseAgent
+from agent_suite.services import EmbeddingService
+
+
+class ProfileAgent(BaseAgent[Dict[str, Any], Dict[str, Any]]):
+    """Collects profile information and generates embeddings."""
+
+    name = "profile-agent"
+
+    def __init__(self, embedding_service: EmbeddingService | None = None) -> None:
+        self._embedding_service = embedding_service or EmbeddingService()
+
+    async def _arun(self, data: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        normalized_profile = self._normalize_profile(data)
+        embedding = self._embedding_service.embed_query(
+            " ".join(normalized_profile.get("skills", []) + normalized_profile.get("interests", []))
+        )
+        normalized_profile["embedding"] = embedding
+        context.metadata["profile"] = normalized_profile
+        return normalized_profile
+
+    def _normalize_profile(self, profile: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = {
+            "full_name": profile.get("full_name", "").strip(),
+            "email": profile.get("email", "").lower().strip(),
+            "education": [item.strip() for item in profile.get("education", [])],
+            "skills": sorted({skill.strip() for skill in profile.get("skills", [])}),
+            "projects": profile.get("projects", []),
+            "interests": sorted({interest.strip() for interest in profile.get("interests", [])}),
+            "preferences": profile.get("preferences", {}),
+        }
+        return normalized
+
+
+__all__ = ["ProfileAgent"]

--- a/agent_suite/agent_suite/agents/resume.py
+++ b/agent_suite/agent_suite/agents/resume.py
@@ -1,0 +1,36 @@
+"""Agent that tailors resumes for each job posting."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from agent_suite.agents.base import AgentContext, BaseAgent
+from agent_suite.services import ResumeBuilder
+
+
+class ResumeAgent(BaseAgent[List[Dict[str, Any]], List[Dict[str, Any]]]):
+    """Generates ATS optimized resume variants."""
+
+    name = "resume-agent"
+
+    def __init__(self, resume_builder: ResumeBuilder | None = None) -> None:
+        self._resume_builder = resume_builder or ResumeBuilder()
+
+    async def _arun(self, data: List[Dict[str, Any]], context: AgentContext) -> List[Dict[str, Any]]:
+        profile = context.metadata.get("profile", {})
+        resume_variants: List[Dict[str, Any]] = []
+        for job in data:
+            resume_result = self._resume_builder.build(profile, job)
+            resume_variants.append(
+                {
+                    "job": job,
+                    "variant_name": resume_result.name,
+                    "content": resume_result.content,
+                    "ats_score": resume_result.ats_score,
+                }
+            )
+        context.metadata["resumes"] = resume_variants
+        return resume_variants
+
+
+__all__ = ["ResumeAgent"]

--- a/agent_suite/agent_suite/agents/search.py
+++ b/agent_suite/agent_suite/agents/search.py
@@ -1,0 +1,33 @@
+"""Agent for searching and ranking job opportunities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from agent_suite.agents.base import AgentContext, BaseAgent
+from agent_suite.services import JobSearchService, SearchFilters
+
+
+class SearchAgent(BaseAgent[Dict[str, Any], List[Dict[str, Any]]]):
+    """Queries job sources and returns ranked opportunities."""
+
+    name = "search-agent"
+
+    def __init__(self, job_search_service: JobSearchService | None = None) -> None:
+        self._job_search_service = job_search_service or JobSearchService()
+
+    async def _arun(self, data: Dict[str, Any], context: AgentContext) -> List[Dict[str, Any]]:
+        profile = context.metadata.get("profile") or data.get("profile")
+        preferences = profile.get("preferences", {}) if profile else {}
+        filters = SearchFilters(
+            keywords=preferences.get("keywords", []),
+            locations=preferences.get("locations"),
+            remote=preferences.get("remote"),
+            min_score=preferences.get("min_score", 0.0),
+        )
+        jobs = self._job_search_service.search(profile, filters)
+        context.metadata["jobs"] = jobs
+        return jobs
+
+
+__all__ = ["SearchAgent"]

--- a/agent_suite/agent_suite/agents/sender.py
+++ b/agent_suite/agent_suite/agents/sender.py
@@ -1,0 +1,39 @@
+"""Agent that sends applications and logs submissions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from agent_suite.agents.base import AgentContext, BaseAgent
+from agent_suite.services import EmailSender
+
+
+class SenderAgent(BaseAgent[List[Dict[str, Any]], List[Dict[str, Any]]]):
+    """Handles email dispatch and submission logging."""
+
+    name = "sender-agent"
+
+    def __init__(self, email_sender: EmailSender | None = None) -> None:
+        self._email_sender = email_sender or EmailSender()
+
+    async def _arun(self, data: List[Dict[str, Any]], context: AgentContext) -> List[Dict[str, Any]]:
+        submissions: List[Dict[str, Any]] = []
+        for payload in data:
+            job = payload["job"]
+            recruiter_email = job.get("recruiter_email", "recruiter@example.com")
+            subject = f"Application: {job['title']} at {job['company']}"
+            email_body = payload["recruiter_email"]
+            result = self._email_sender.send_email(
+                sender=context.metadata.get("profile", {}).get("email", "candidate@example.com"),
+                recipient=recruiter_email,
+                subject=subject,
+                body=email_body,
+            )
+            submission = dict(payload)
+            submission["send_result"] = result.__dict__
+            submissions.append(submission)
+        context.metadata["submissions"] = submissions
+        return submissions
+
+
+__all__ = ["SenderAgent"]

--- a/agent_suite/agent_suite/agents/tracker.py
+++ b/agent_suite/agent_suite/agents/tracker.py
@@ -1,0 +1,41 @@
+"""Agent that updates the application tracker dashboard."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from agent_suite.agents.base import AgentContext, BaseAgent
+from agent_suite.services import ApplicationTracker
+
+
+class TrackerAgent(BaseAgent[List[Dict[str, Any]], List[Dict[str, Any]]]):
+    """Tracks responses and follow-up actions."""
+
+    name = "tracker-agent"
+
+    def __init__(self, tracker: ApplicationTracker | None = None) -> None:
+        self._tracker = tracker or ApplicationTracker()
+
+    async def _arun(self, data: List[Dict[str, Any]], context: AgentContext) -> List[Dict[str, Any]]:
+        dashboard_entries: List[Dict[str, Any]] = []
+        for submission in data:
+            job = submission["job"]
+            result = self._tracker.log_event(
+                job_id=str(job.get("id", job.get("url", "unknown"))),
+                job_title=job.get("title", "Unknown"),
+                company=job.get("company", "Unknown"),
+                status="submitted" if submission.get("send_result", {}).get("success") else "error",
+                notes=submission.get("send_result", {}).get("error", ""),
+            )
+            dashboard_entries.append(
+                {
+                    "job": job,
+                    "status": result.status,
+                    "events": [event.__dict__ for event in result.events],
+                }
+            )
+        context.metadata["dashboard"] = dashboard_entries
+        return dashboard_entries
+
+
+__all__ = ["TrackerAgent"]

--- a/agent_suite/agent_suite/api/__init__.py
+++ b/agent_suite/agent_suite/api/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI application exposing Agent Suite workflows."""
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/agent_suite/agent_suite/api/main.py
+++ b/agent_suite/agent_suite/api/main.py
@@ -1,0 +1,23 @@
+"""FastAPI entrypoint for Agent Suite."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from agent_suite.api.routers import workflow_router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="Agent Suite – AI-Powered Career Assistant", version="0.1.0")
+
+    @app.get("/health", tags=["system"])
+    async def health_check() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.include_router(workflow_router)
+    return app
+
+
+app = create_app()
+
+__all__ = ["create_app", "app"]

--- a/agent_suite/agent_suite/api/routers/__init__.py
+++ b/agent_suite/agent_suite/api/routers/__init__.py
@@ -1,0 +1,5 @@
+"""API routers for the FastAPI app."""
+
+from .workflow import router as workflow_router
+
+__all__ = ["workflow_router"]

--- a/agent_suite/agent_suite/api/routers/workflow.py
+++ b/agent_suite/agent_suite/api/routers/workflow.py
@@ -1,0 +1,55 @@
+"""Routes for executing the Agent Suite workflow."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from agent_suite.workflows import ApplicationState, ApplicationWorkflow
+
+router = APIRouter(prefix="/workflow", tags=["workflow"])
+
+
+class Project(BaseModel):
+    name: str
+    description: str
+    impact: str = ""
+
+
+class ProfilePayload(BaseModel):
+    full_name: str
+    email: str
+    education: List[str]
+    skills: List[str]
+    projects: List[Project] = Field(default_factory=list)
+    interests: List[str] = Field(default_factory=list)
+    preferences: Dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkflowRequest(BaseModel):
+    profile: ProfilePayload
+    auto_send: bool = True
+
+
+class WorkflowResponse(BaseModel):
+    dashboard: List[Dict[str, Any]]
+    submissions: List[Dict[str, Any]]
+    review_status: str
+
+
+@router.post("/run", response_model=WorkflowResponse)
+async def run_workflow(request: WorkflowRequest) -> WorkflowResponse:
+    workflow = ApplicationWorkflow()
+    final_state = await workflow.run(ApplicationState(profile=request.profile.model_dump(), auto_send=request.auto_send))
+    if request.auto_send is False and final_state.get("review_status") != "auto":
+        raise HTTPException(status_code=202, detail="Awaiting human review")
+    return WorkflowResponse(
+        dashboard=final_state.get("dashboard", []),
+        submissions=final_state.get("submissions", []),
+        review_status=final_state.get("review_status", "unknown"),
+    )
+
+
+__all__ = ["router"]

--- a/agent_suite/agent_suite/assets/evaluation_plan.md
+++ b/agent_suite/agent_suite/assets/evaluation_plan.md
@@ -1,0 +1,7 @@
+# Evaluation Strategy
+
+1. **Job Relevance** – Compare ranked job list against manually curated opportunities from IIT Kanpur faculty labs. Calculate precision@5 and recall metrics.
+2. **Communication Quality** – Use rubric (clarity, professionalism, personalization) scored by human reviewers on a 1-5 scale. Target average score ≥4.
+3. **ATS Improvements** – Benchmark ATS scores of baseline resumes vs. tailored variants using third-party ATS testers; target ≥15% improvement.
+4. **Live Pilots** – Conduct end-to-end submissions to IIT Kanpur faculty research postings, measure response rates, and track interview conversions.
+5. **Observability** – Capture Prometheus metrics (jobs fetched, emails sent, review pauses) and monitor errors via Sentry dashboards.

--- a/agent_suite/agent_suite/config/__init__.py
+++ b/agent_suite/agent_suite/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration management for Agent Suite."""
+
+from .settings import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/agent_suite/agent_suite/config/settings.py
+++ b/agent_suite/agent_suite/config/settings.py
@@ -1,0 +1,50 @@
+"""Application settings using environment variables."""
+
+from functools import lru_cache
+from typing import List
+
+from pydantic import AnyUrl, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Base configuration for the Agent Suite application."""
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    openai_api_key: str = Field(default="", description="OpenAI compatible API key")
+    anthropic_api_key: str = Field(default="", description="Anthropic API key")
+    groq_api_key: str = Field(default="", description="GroqCloud API key")
+
+    postgres_dsn: AnyUrl = Field(
+        default="postgresql+asyncpg://agent_suite:agent_suite@localhost:5432/agent_suite",
+        description="PostgreSQL DSN for SQLAlchemy async engine",
+    )
+    vector_store: str = Field(default="pgvector", description="Semantic store backend identifier")
+
+    embeddings_model: str = Field(default="text-embedding-3-large", description="Embedding model name")
+    llm_model: str = Field(default="gpt-4-turbo", description="Default LLM model name")
+    temperature: float = Field(default=0.2, ge=0, le=1, description="Default sampling temperature")
+
+    job_sources: List[str] = Field(
+        default_factory=lambda: ["indeed", "linkedin", "google_jobs"],
+        description="External job source identifiers",
+    )
+    allowed_email_domains: List[str] = Field(
+        default_factory=lambda: ["gmail.com", "outlook.com"],
+        description="Allowed email domains for sender agent",
+    )
+    observability_endpoint: str = Field(
+        default="http://localhost:9090",
+        description="Prometheus push gateway endpoint for metrics",
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return cached settings instance."""
+
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/agent_suite/agent_suite/data/ats_keywords.json
+++ b/agent_suite/agent_suite/data/ats_keywords.json
@@ -1,0 +1,5 @@
+{
+  "ai_research": ["machine learning", "deep learning", "python", "pytorch", "langchain"],
+  "full_stack": ["react", "node.js", "fastapi", "postgresql", "docker"],
+  "data_science": ["sql", "statistics", "pandas", "scikit-learn", "visualization"]
+}

--- a/agent_suite/agent_suite/data/sample_jobs.json
+++ b/agent_suite/agent_suite/data/sample_jobs.json
@@ -1,0 +1,22 @@
+[
+  {
+    "source": "linkedin",
+    "title": "AI Research Intern",
+    "company": "IIT Kanpur AI Lab",
+    "location": "Kanpur, India",
+    "url": "https://www.linkedin.com/jobs/view/123",
+    "description": "Work on cutting-edge AI research, build models, and collaborate with faculty.",
+    "skills": ["Python", "Machine Learning", "Deep Learning", "LangChain"],
+    "posted_at": "2024-06-01"
+  },
+  {
+    "source": "indeed",
+    "title": "Remote AI Product Intern",
+    "company": "Innovative Startups",
+    "location": "Remote",
+    "url": "https://www.indeed.com/viewjob?jk=456",
+    "description": "Develop AI-driven web applications, integrate APIs, and deploy on cloud platforms.",
+    "skills": ["React", "FastAPI", "PostgreSQL", "AI"],
+    "posted_at": "2024-06-03"
+  }
+]

--- a/agent_suite/agent_suite/db/__init__.py
+++ b/agent_suite/agent_suite/db/__init__.py
@@ -1,0 +1,21 @@
+"""Database utilities for Agent Suite."""
+
+from .base import async_engine, async_session_factory, Base
+from .models import (
+    ApplicationLog,
+    ApplicationStatus,
+    JobPosting,
+    Profile,
+    ResumeVariant,
+)
+
+__all__ = [
+    "async_engine",
+    "async_session_factory",
+    "Base",
+    "ApplicationLog",
+    "ApplicationStatus",
+    "JobPosting",
+    "Profile",
+    "ResumeVariant",
+]

--- a/agent_suite/agent_suite/db/base.py
+++ b/agent_suite/agent_suite/db/base.py
@@ -1,0 +1,19 @@
+"""SQLAlchemy async engine and session configuration."""
+
+from sqlalchemy.ext.asyncio import AsyncAttrs, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+from agent_suite.config import get_settings
+
+
+settings = get_settings()
+
+
+class Base(AsyncAttrs, DeclarativeBase):
+    """Declarative base class that supports async flush/refresh."""
+
+
+async_engine = create_async_engine(str(settings.postgres_dsn), echo=False)
+async_session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
+
+__all__ = ["Base", "async_engine", "async_session_factory"]

--- a/agent_suite/agent_suite/db/models.py
+++ b/agent_suite/agent_suite/db/models.py
@@ -1,0 +1,110 @@
+"""Database models representing core Agent Suite entities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import JSON, DateTime, Enum as SQLEnum, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class ApplicationStatus(str, Enum):
+    """Lifecycle status for a submitted application."""
+
+    DRAFT = "draft"
+    SUBMITTED = "submitted"
+    INTERVIEW = "interview"
+    OFFER = "offer"
+    REJECTED = "rejected"
+    WITHDRAWN = "withdrawn"
+
+
+class Profile(Base):
+    """User profile containing normalized data and embeddings."""
+
+    __tablename__ = "profiles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    full_name: Mapped[str] = mapped_column(String(255))
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    education: Mapped[List[str]] = mapped_column(ARRAY(String(255)))
+    skills: Mapped[List[str]] = mapped_column(ARRAY(String(255)))
+    interests: Mapped[List[str]] = mapped_column(ARRAY(String(255)))
+    normalized_profile: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
+    embedding: Mapped[List[float]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    resumes: Mapped[List["ResumeVariant"]] = relationship(back_populates="profile")
+    applications: Mapped[List["ApplicationLog"]] = relationship(back_populates="profile")
+
+
+class JobPosting(Base):
+    """Normalized job posting data with structured fields."""
+
+    __tablename__ = "job_postings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    source: Mapped[str] = mapped_column(String(50), index=True)
+    title: Mapped[str] = mapped_column(String(255))
+    company: Mapped[str] = mapped_column(String(255))
+    location: Mapped[Optional[str]] = mapped_column(String(255))
+    url: Mapped[Optional[str]] = mapped_column(Text)
+    description: Mapped[str] = mapped_column(Text)
+    structured_data: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
+    ranking_score: Mapped[float] = mapped_column(default=0.0)
+    posted_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    ingested_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    resumes: Mapped[List["ResumeVariant"]] = relationship(back_populates="job")
+    applications: Mapped[List["ApplicationLog"]] = relationship(back_populates="job")
+
+
+class ResumeVariant(Base):
+    """Resume tailored for a specific job posting."""
+
+    __tablename__ = "resume_variants"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    profile_id: Mapped[int] = mapped_column(ForeignKey("profiles.id"), nullable=False)
+    job_id: Mapped[int] = mapped_column(ForeignKey("job_postings.id"), nullable=False)
+    variant_name: Mapped[str] = mapped_column(String(255))
+    content: Mapped[str] = mapped_column(Text)
+    ats_score: Mapped[float] = mapped_column(default=0.0)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    profile: Mapped[Profile] = relationship(back_populates="resumes")
+    job: Mapped[JobPosting] = relationship(back_populates="resumes")
+
+
+class ApplicationLog(Base):
+    """Audit log for application submissions and interactions."""
+
+    __tablename__ = "application_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    profile_id: Mapped[int] = mapped_column(ForeignKey("profiles.id"), nullable=False)
+    job_id: Mapped[int] = mapped_column(ForeignKey("job_postings.id"), nullable=False)
+    status: Mapped[ApplicationStatus] = mapped_column(SQLEnum(ApplicationStatus), default=ApplicationStatus.DRAFT)
+    cover_letter: Mapped[Optional[str]] = mapped_column(Text)
+    recruiter_email: Mapped[Optional[str]] = mapped_column(Text)
+    metadata: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    profile: Mapped[Profile] = relationship(back_populates="applications")
+    job: Mapped[JobPosting] = relationship(back_populates="applications")
+
+
+__all__ = [
+    "ApplicationLog",
+    "ApplicationStatus",
+    "JobPosting",
+    "Profile",
+    "ResumeVariant",
+]

--- a/agent_suite/agent_suite/db/schema.sql
+++ b/agent_suite/agent_suite/db/schema.sql
@@ -1,0 +1,51 @@
+-- SQL schema for Agent Suite core tables.
+CREATE TABLE IF NOT EXISTS profiles (
+    id SERIAL PRIMARY KEY,
+    full_name TEXT NOT NULL,
+    email TEXT UNIQUE NOT NULL,
+    education TEXT[],
+    skills TEXT[],
+    interests TEXT[],
+    normalized_profile JSONB DEFAULT '{}'::jsonb,
+    embedding JSONB DEFAULT '[]'::jsonb,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS job_postings (
+    id SERIAL PRIMARY KEY,
+    source TEXT,
+    title TEXT,
+    company TEXT,
+    location TEXT,
+    url TEXT,
+    description TEXT,
+    structured_data JSONB DEFAULT '{}'::jsonb,
+    ranking_score DOUBLE PRECISION DEFAULT 0,
+    posted_at TIMESTAMP,
+    ingested_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TYPE application_status AS ENUM ('draft', 'submitted', 'interview', 'offer', 'rejected', 'withdrawn');
+
+CREATE TABLE IF NOT EXISTS resume_variants (
+    id SERIAL PRIMARY KEY,
+    profile_id INTEGER REFERENCES profiles(id),
+    job_id INTEGER REFERENCES job_postings(id),
+    variant_name TEXT,
+    content TEXT,
+    ats_score DOUBLE PRECISION DEFAULT 0,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS application_logs (
+    id SERIAL PRIMARY KEY,
+    profile_id INTEGER REFERENCES profiles(id),
+    job_id INTEGER REFERENCES job_postings(id),
+    status application_status DEFAULT 'draft',
+    cover_letter TEXT,
+    recruiter_email TEXT,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);

--- a/agent_suite/agent_suite/services/__init__.py
+++ b/agent_suite/agent_suite/services/__init__.py
@@ -1,0 +1,20 @@
+"""Supporting services used by the agents."""
+
+from .embedding import EmbeddingService
+from .job_search import JobSearchService, SearchFilters
+from .jd_parser import JobDescriptionParser
+from .resume_builder import ResumeBuilder
+from .comms_builder import CommunicationsBuilder
+from .email_sender import EmailSender
+from .tracker import ApplicationTracker
+
+__all__ = [
+    "EmbeddingService",
+    "JobSearchService",
+    "SearchFilters",
+    "JobDescriptionParser",
+    "ResumeBuilder",
+    "CommunicationsBuilder",
+    "EmailSender",
+    "ApplicationTracker",
+]

--- a/agent_suite/agent_suite/services/comms_builder.py
+++ b/agent_suite/agent_suite/services/comms_builder.py
@@ -1,0 +1,43 @@
+"""Generate personalized communication artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+
+@dataclass
+class CommunicationsResult:
+    """Bundle of generated communication assets."""
+
+    cover_letter: str
+    recruiter_email: str
+
+
+class CommunicationsBuilder:
+    """Render cover letters and recruiter outreach emails."""
+
+    def __init__(self) -> None:
+        self._jinja_env = Environment(
+            loader=PackageLoader("agent_suite", "templates"),
+            autoescape=select_autoescape(),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+
+    def build(self, profile: Dict[str, Any], job: Dict[str, Any], tone: str = "professional") -> CommunicationsResult:
+        cover_letter_template = self._jinja_env.get_template("cover_letter_template.j2")
+        recruiter_email_template = self._jinja_env.get_template("recruiter_email_template.j2")
+        context = {
+            "profile": profile,
+            "job": job,
+            "tone": tone,
+        }
+        cover_letter = cover_letter_template.render(**context)
+        recruiter_email = recruiter_email_template.render(**context)
+        return CommunicationsResult(cover_letter=cover_letter, recruiter_email=recruiter_email)
+
+
+__all__ = ["CommunicationsBuilder", "CommunicationsResult"]

--- a/agent_suite/agent_suite/services/email_sender.py
+++ b/agent_suite/agent_suite/services/email_sender.py
@@ -1,0 +1,33 @@
+"""Email sending abstraction for Gmail/SMTP integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from structlog import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class EmailResult:
+    """Outcome of an email sending operation."""
+
+    success: bool
+    message_id: Optional[str] = None
+    error: Optional[str] = None
+
+
+class EmailSender:
+    """Simplified email sender stub; integrate Gmail API/SMTP in production."""
+
+    def send_email(self, sender: str, recipient: str, subject: str, body: str) -> EmailResult:
+        if "@" not in recipient:
+            return EmailResult(success=False, error="Invalid recipient")
+        message_id = f"msg_{abs(hash((sender, recipient, subject))) % (10**10)}"
+        logger.info("email.send", sender=sender, recipient=recipient, subject=subject)
+        return EmailResult(success=True, message_id=message_id)
+
+
+__all__ = ["EmailSender", "EmailResult"]

--- a/agent_suite/agent_suite/services/embedding.py
+++ b/agent_suite/agent_suite/services/embedding.py
@@ -1,0 +1,60 @@
+"""Embedding utilities for profile and job semantic representation."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Iterable, List
+
+from langchain_core.embeddings import Embeddings
+from langchain_openai import OpenAIEmbeddings
+
+from agent_suite.config import get_settings
+
+
+class EmbeddingService:
+    """Wrapper around LangChain embeddings with deterministic fallback."""
+
+    def __init__(self) -> None:
+        self._settings = get_settings()
+        self._client: Embeddings | None = None
+
+    @property
+    def client(self) -> Embeddings:
+        """Return configured embeddings provider."""
+
+        if self._client is None:
+            if self._settings.openai_api_key:
+                self._client = OpenAIEmbeddings(model=self._settings.embeddings_model)
+            else:  # pragma: no cover - environment specific
+                self._client = _DeterministicEmbeddings()
+        return self._client
+
+    def embed_documents(self, documents: Iterable[str]) -> List[List[float]]:
+        """Embed a sequence of documents."""
+
+        return self.client.embed_documents(list(documents))
+
+    def embed_query(self, query: str) -> List[float]:
+        """Embed a single query string."""
+
+        return self.client.embed_query(query)
+
+
+class _DeterministicEmbeddings(Embeddings):
+    """Fallback embedding generator used for offline/local testing."""
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:  # type: ignore[override]
+        return [self.embed_query(text) for text in texts]
+
+    def embed_query(self, text: str) -> List[float]:  # type: ignore[override]
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        return [byte / 255 for byte in digest[:32]]
+
+    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:  # pragma: no cover - sync fallback
+        return self.embed_documents(texts)
+
+    async def aembed_query(self, text: str) -> List[float]:  # pragma: no cover - sync fallback
+        return self.embed_query(text)
+
+
+__all__ = ["EmbeddingService"]

--- a/agent_suite/agent_suite/services/jd_parser.py
+++ b/agent_suite/agent_suite/services/jd_parser.py
@@ -1,0 +1,53 @@
+"""Structured parsing for job descriptions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import re
+
+from structlog import get_logger
+
+logger = get_logger(__name__)
+
+RESPONSIBILITY_REGEX = re.compile(r"(?:responsibilities|what you will do)[:\n]\s*(.*)", re.IGNORECASE | re.DOTALL)
+REQUIREMENT_REGEX = re.compile(r"(?:requirements|qualifications)[:\n]\s*(.*)", re.IGNORECASE | re.DOTALL)
+
+
+class JobDescriptionParser:
+    """Extract structured data from raw job descriptions."""
+
+    def parse(self, description: str) -> Dict[str, Any]:
+        """Parse description text into structured schema."""
+
+        responsibilities = self._split_section(description, RESPONSIBILITY_REGEX)
+        requirements = self._split_section(description, REQUIREMENT_REGEX)
+        keywords = self._extract_keywords(description)
+        logger.info(
+            "jd_parser.parse",
+            responsibilities=len(responsibilities),
+            requirements=len(requirements),
+            keywords=len(keywords),
+        )
+        return {
+            "responsibilities": responsibilities,
+            "requirements": requirements,
+            "keywords": keywords,
+        }
+
+    def _split_section(self, description: str, pattern: re.Pattern[str]) -> list[str]:
+        match = pattern.search(description)
+        if not match:
+            return []
+        section = match.group(1)
+        items = [item.strip(" -\n\t") for item in re.split(r"[\n\r]\s*[-*]?", section) if item.strip()]
+        return items
+
+    def _extract_keywords(self, description: str) -> list[str]:
+        tokens = {token.lower().strip(".,") for token in description.split() if len(token) > 2}
+        # filter out common stop words (very small list for demo purposes)
+        stop_words = {"the", "and", "with", "will", "you", "for", "are"}
+        return sorted(token for token in tokens if token not in stop_words)
+
+
+__all__ = ["JobDescriptionParser"]

--- a/agent_suite/agent_suite/services/job_search.py
+++ b/agent_suite/agent_suite/services/job_search.py
@@ -1,0 +1,93 @@
+"""Job search service with pluggable data sources."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from structlog import get_logger
+
+from agent_suite.services.embedding import EmbeddingService
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class SearchFilters:
+    """Filtering options provided to the job search service."""
+
+    keywords: List[str]
+    locations: Optional[List[str]] = None
+    remote: Optional[bool] = None
+    min_score: float = 0.0
+
+
+class JobSearchService:
+    """Loads and ranks job postings using semantic similarity."""
+
+    def __init__(self, embedding_service: Optional[EmbeddingService] = None) -> None:
+        self._embedding_service = embedding_service or EmbeddingService()
+        self._data_path = Path(__file__).resolve().parents[1] / "data" / "sample_jobs.json"
+
+    def _load_jobs(self) -> List[Dict[str, Any]]:
+        """Load job postings from configured sources."""
+
+        if not self._data_path.exists():  # pragma: no cover - runtime guard
+            logger.warning("Sample job dataset not found", path=str(self._data_path))
+            return []
+        with self._data_path.open() as handle:
+            return json.load(handle)
+
+    def _compute_similarity(self, profile_embedding: List[float], job: Dict[str, Any]) -> float:
+        job_vector = self._embedding_service.embed_query(
+            " ".join([job["title"], job["company"], job.get("description", "")])
+        )
+        if not profile_embedding or not job_vector:
+            return 0.0
+        length = min(len(profile_embedding), len(job_vector))
+        score = sum(profile_embedding[i] * job_vector[i] for i in range(length))
+        return score / length
+
+    def search(self, profile: Dict[str, Any], filters: SearchFilters) -> List[Dict[str, Any]]:
+        """Return ranked job postings for the given profile."""
+
+        profile_vector = self._embedding_service.embed_query(
+            " ".join(profile.get("skills", []) + profile.get("interests", []))
+        )
+        matched_jobs: List[Dict[str, Any]] = []
+        for job in self._load_jobs():
+            if filters.locations and job.get("location") not in filters.locations:
+                continue
+            if filters.remote is True and "remote" not in job.get("location", "").lower():
+                continue
+            if filters.remote is False and "remote" in job.get("location", "").lower():
+                continue
+            if filters.keywords and not any(
+                keyword.lower() in (job.get("description", "") + job.get("title", "")).lower()
+                for keyword in filters.keywords
+            ):
+                continue
+
+            score = self._compute_similarity(profile_vector, job)
+            if score < filters.min_score:
+                continue
+            job_copy = dict(job)
+            job_copy["ranking_score"] = score
+            job_copy["structured_data"] = {
+                "skills": job.get("skills", []),
+                "keywords": job.get("skills", []),
+                "responsibilities": job.get("description", "").split(","),
+            }
+            if job.get("posted_at"):
+                job_copy["posted_at"] = datetime.fromisoformat(job["posted_at"])
+            matched_jobs.append(job_copy)
+
+        matched_jobs.sort(key=lambda job: job.get("ranking_score", 0), reverse=True)
+        logger.info("search.results", count=len(matched_jobs))
+        return matched_jobs
+
+
+__all__ = ["JobSearchService", "SearchFilters"]

--- a/agent_suite/agent_suite/services/resume_builder.py
+++ b/agent_suite/agent_suite/services/resume_builder.py
@@ -1,0 +1,57 @@
+"""Resume tailoring utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+
+@dataclass
+class ResumeBuildResult:
+    """Structured result for a resume variant."""
+
+    name: str
+    content: str
+    ats_score: float
+
+
+class ResumeBuilder:
+    """Generate ATS friendly resumes by matching profile and job requirements."""
+
+    def __init__(self) -> None:
+        self._jinja_env = Environment(
+            loader=PackageLoader("agent_suite", "templates"),
+            autoescape=select_autoescape(),
+        )
+
+    def build(self, profile: Dict[str, Any], job: Dict[str, Any]) -> ResumeBuildResult:
+        template = self._jinja_env.get_template("resume_template.j2")
+        matched_skills = self._match_skills(
+            profile.get("skills", []), job.get("structured_data", {}).get("keywords", [])
+        )
+        ats_score = self._compute_ats_score(profile, job)
+        content = template.render(
+            profile=profile,
+            job=job,
+            matched_skills=matched_skills,
+            ats_score=ats_score,
+        )
+        variant_name = f"{job['title']} - {job['company']}"
+        return ResumeBuildResult(name=variant_name, content=content, ats_score=ats_score)
+
+    def _match_skills(self, profile_skills: List[str], job_keywords: List[str]) -> List[str]:
+        lower_keywords = {keyword.lower() for keyword in job_keywords}
+        return [skill for skill in profile_skills if skill.lower() in lower_keywords]
+
+    def _compute_ats_score(self, profile: Dict[str, Any], job: Dict[str, Any]) -> float:
+        job_keywords = job.get("structured_data", {}).get("keywords", [])
+        if not job_keywords:
+            return 0.0
+        matched = len(self._match_skills(profile.get("skills", []), job_keywords))
+        score = matched / len(job_keywords)
+        return round(score, 2)
+
+
+__all__ = ["ResumeBuilder", "ResumeBuildResult"]

--- a/agent_suite/agent_suite/services/tracker.py
+++ b/agent_suite/agent_suite/services/tracker.py
@@ -1,0 +1,55 @@
+"""Application tracking service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Dict, List
+
+from structlog import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ApplicationEvent:
+    """Represents a tracked event for an application."""
+
+    timestamp: datetime
+    status: str
+    notes: str = ""
+
+
+@dataclass
+class TrackedApplication:
+    """State container for an individual application."""
+
+    job_title: str
+    company: str
+    status: str
+    events: List[ApplicationEvent] = field(default_factory=list)
+
+
+class ApplicationTracker:
+    """Stores and updates application statuses."""
+
+    def __init__(self) -> None:
+        self._applications: Dict[str, TrackedApplication] = {}
+
+    def log_event(self, job_id: str, job_title: str, company: str, status: str, notes: str = "") -> TrackedApplication:
+        key = f"{job_id}:{company}"
+        event = ApplicationEvent(timestamp=datetime.now(UTC), status=status, notes=notes)
+        application = self._applications.get(key)
+        if application is None:
+            application = TrackedApplication(job_title=job_title, company=company, status=status)
+            self._applications[key] = application
+        application.events.append(event)
+        application.status = status
+        logger.info("tracker.log", job_id=job_id, status=status)
+        return application
+
+    def dashboard(self) -> List[TrackedApplication]:
+        return list(self._applications.values())
+
+
+__all__ = ["ApplicationTracker", "TrackedApplication", "ApplicationEvent"]

--- a/agent_suite/agent_suite/templates/cover_letter_template.j2
+++ b/agent_suite/agent_suite/templates/cover_letter_template.j2
@@ -1,0 +1,12 @@
+Dear Hiring Manager,
+
+I am excited to apply for the {{ job.title }} position at {{ job.company }}. My experience across {% for skill in profile.skills %}{{ skill }}{% if not loop.last %}, {% endif %}{% endfor %} and passion for {{ tone }} collaboration align well with your requirements.
+
+Key highlights:
+{% for project in profile.projects %}- {{ project.name }}: {{ project.impact }}
+{% endfor %}
+
+Thank you for considering my application. I look forward to the opportunity to contribute to {{ job.company }}.
+
+Sincerely,
+{{ profile.full_name }}

--- a/agent_suite/agent_suite/templates/recruiter_email_template.j2
+++ b/agent_suite/agent_suite/templates/recruiter_email_template.j2
@@ -1,0 +1,13 @@
+Subject: Application for {{ job.title }} – {{ profile.full_name }}
+
+Hi {{ job.company }} Recruitment Team,
+
+I just submitted my application for the {{ job.title }} role and wanted to share a brief highlight:
+{% for project in profile.projects %}- {{ project.name }}: {{ project.impact }}
+{% endfor %}
+
+I would love to discuss how my background fits the team's goals.
+
+Best regards,
+{{ profile.full_name }}
+{{ profile.email }}

--- a/agent_suite/agent_suite/templates/resume_template.j2
+++ b/agent_suite/agent_suite/templates/resume_template.j2
@@ -1,0 +1,23 @@
+{{ profile.full_name }}
+{{ profile.email }}
+
+Objective
+---------
+Motivated candidate applying for the {{ job.title }} role at {{ job.company }}.
+
+Matched Skills
+--------------
+{% for skill in matched_skills %}- {{ skill }}
+{% endfor %}
+
+Experience & Projects
+---------------------
+{% for project in profile.projects %}- {{ project.name }}: {{ project.description }}
+{% endfor %}
+
+Education
+---------
+{% for edu in profile.education %}- {{ edu }}
+{% endfor %}
+
+ATS Score: {{ ats_score * 100 }}%

--- a/agent_suite/agent_suite/workflows/__init__.py
+++ b/agent_suite/agent_suite/workflows/__init__.py
@@ -1,0 +1,5 @@
+"""Workflow orchestrations built on LangGraph."""
+
+from .application_flow import ApplicationWorkflow, ApplicationState
+
+__all__ = ["ApplicationWorkflow", "ApplicationState"]

--- a/agent_suite/agent_suite/workflows/application_flow.py
+++ b/agent_suite/agent_suite/workflows/application_flow.py
@@ -1,0 +1,134 @@
+"""LangGraph workflow orchestrating the Agent Suite pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, TypedDict
+
+from langgraph.graph import END, StateGraph
+
+from agent_suite.agents import (
+    AgentContext,
+    CommunicationsAgent,
+    JobDescriptionParserAgent,
+    ProfileAgent,
+    ResumeAgent,
+    SearchAgent,
+    SenderAgent,
+    TrackerAgent,
+)
+
+
+class ApplicationState(TypedDict, total=False):
+    """Shared state flowing through the workflow graph."""
+
+    profile: Dict[str, Any]
+    jobs: List[Dict[str, Any]]
+    parsed_jobs: List[Dict[str, Any]]
+    resumes: List[Dict[str, Any]]
+    communications: List[Dict[str, Any]]
+    submissions: List[Dict[str, Any]]
+    dashboard: List[Dict[str, Any]]
+    auto_send: bool
+    review_status: str
+
+
+class ApplicationWorkflow:
+    """Build and execute the Agent Suite LangGraph workflow."""
+
+    def __init__(self) -> None:
+        self._context = AgentContext()
+        self._profile_agent = ProfileAgent()
+        self._search_agent = SearchAgent()
+        self._parser_agent = JobDescriptionParserAgent()
+        self._resume_agent = ResumeAgent()
+        self._comms_agent = CommunicationsAgent()
+        self._sender_agent = SenderAgent()
+        self._tracker_agent = TrackerAgent()
+        self._graph = self._build_graph()
+
+    def _build_graph(self) -> StateGraph[ApplicationState]:
+        graph: StateGraph[ApplicationState] = StateGraph(ApplicationState)
+
+        graph.add_node("profile_agent", self._profile_node)
+        graph.add_node("search_agent", self._search_node)
+        graph.add_node("jd_parser_agent", self._jd_parser_node)
+        graph.add_node("resume_agent", self._resume_node)
+        graph.add_node("communications_agent", self._communications_node)
+        graph.add_node("human_review", self._human_review_node)
+        graph.add_node("sender_agent", self._sender_node)
+        graph.add_node("tracker_agent", self._tracker_node)
+
+        graph.set_entry_point("profile_agent")
+        graph.add_edge("profile_agent", "search_agent")
+        graph.add_edge("search_agent", "jd_parser_agent")
+        graph.add_edge("jd_parser_agent", "resume_agent")
+        graph.add_edge("resume_agent", "communications_agent")
+        graph.add_edge("communications_agent", "human_review")
+        graph.add_conditional_edges(
+            "human_review",
+            self._review_decision,
+            {
+                "auto": "sender_agent",
+                "pending": END,
+            },
+        )
+        graph.add_edge("sender_agent", "tracker_agent")
+        graph.add_edge("tracker_agent", END)
+
+        return graph
+
+    async def run(self, initial_state: ApplicationState) -> ApplicationState:
+        """Execute the workflow asynchronously."""
+
+        compiled = self._graph.compile()
+        result_state: ApplicationState = await compiled.ainvoke(initial_state)
+        return result_state
+
+    async def _profile_node(self, state: ApplicationState) -> ApplicationState:
+        profile_data = state.get("profile", {})
+        result = await self._profile_agent.arun(profile_data, self._context)
+        state["profile"] = result.output
+        return state
+
+    async def _search_node(self, state: ApplicationState) -> ApplicationState:
+        result = await self._search_agent.arun(state, self._context)
+        state["jobs"] = result.output
+        return state
+
+    async def _jd_parser_node(self, state: ApplicationState) -> ApplicationState:
+        result = await self._parser_agent.arun(state.get("jobs", []), self._context)
+        state["parsed_jobs"] = result.output
+        return state
+
+    async def _resume_node(self, state: ApplicationState) -> ApplicationState:
+        result = await self._resume_agent.arun(state.get("parsed_jobs", []), self._context)
+        state["resumes"] = result.output
+        return state
+
+    async def _communications_node(self, state: ApplicationState) -> ApplicationState:
+        result = await self._comms_agent.arun(state.get("resumes", []), self._context)
+        state["communications"] = result.output
+        return state
+
+    async def _human_review_node(self, state: ApplicationState) -> ApplicationState:
+        if not state.get("auto_send", True):
+            state["review_status"] = "pending"
+        else:
+            state["review_status"] = "auto"
+        return state
+
+    def _review_decision(self, state: ApplicationState) -> str:
+        return "auto" if state.get("review_status") == "auto" else "pending"
+
+    async def _sender_node(self, state: ApplicationState) -> ApplicationState:
+        result = await self._sender_agent.arun(state.get("communications", []), self._context)
+        state["submissions"] = result.output
+        return state
+
+    async def _tracker_node(self, state: ApplicationState) -> ApplicationState:
+        result = await self._tracker_agent.arun(state.get("submissions", []), self._context)
+        state["dashboard"] = result.output
+        return state
+
+
+__all__ = ["ApplicationWorkflow", "ApplicationState"]

--- a/agent_suite/pyproject.toml
+++ b/agent_suite/pyproject.toml
@@ -1,0 +1,44 @@
+[tool.poetry]
+name = "agent-suite"
+version = "0.1.0"
+description = "Agent Suite – AI-Powered Career Assistant built with LangGraph"
+authors = ["Agent Developer <agent@example.com>"]
+license = "MIT"
+readme = "README.md"
+packages = [{include = "agent_suite"}]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.110.0"
+uvicorn = {extras = ["standard"], version = "^0.29.0"}
+langchain = "^0.2.0"
+langgraph = "^0.0.40"
+langchain-openai = "^0.1.6"
+httpx = "^0.27.0"
+pydantic = "^2.7.0"
+pydantic-settings = "^2.2.1"
+SQLAlchemy = "^2.0.29"
+asyncpg = "^0.29.0"
+pgvector = "^0.2.5"
+psycopg2-binary = "^2.9.9"
+python-docx = "^1.1.0"
+reportlab = "^4.0.9"
+Jinja2 = "^3.1.3"
+playwright = "^1.43.0"
+beautifulsoup4 = "^4.12.3"
+selectolax = "^0.3.17"
+requests = "^2.31.0"
+typing-extensions = "^4.10.0"
+structlog = "^24.1.0"
+prometheus-client = "^0.20.0"
+sentry-sdk = "^1.43.0"
+faiss-cpu = "^1.8.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.1.1"
+pytest-asyncio = "^0.23.5"
+ruff = "^0.3.7"
+
+[build-system]
+requires = ["poetry-core>=1.8.2"]
+build-backend = "poetry.core.masonry.api"

--- a/agent_suite/scripts/run_example.py
+++ b/agent_suite/scripts/run_example.py
@@ -1,0 +1,33 @@
+"""Example script running the Agent Suite workflow end-to-end."""
+
+from __future__ import annotations
+
+import asyncio
+from pprint import pprint
+
+from agent_suite.workflows import ApplicationState, ApplicationWorkflow
+
+
+async def main() -> None:
+    workflow = ApplicationWorkflow()
+    example_profile = {
+        "full_name": "Aditi Sharma",
+        "email": "aditi@example.com",
+        "education": ["B.Tech Computer Science – IIT Kanpur"],
+        "skills": ["Python", "Machine Learning", "LangChain", "FastAPI"],
+        "projects": [
+            {
+                "name": "Autonomous Agent Research",
+                "description": "Explored multi-agent coordination for job search automation.",
+                "impact": "Improved matching accuracy by 25%",
+            }
+        ],
+        "interests": ["AI Research", "Autonomous Agents"],
+        "preferences": {"keywords": ["AI", "research"], "locations": ["Kanpur, India", "Remote"], "remote": True},
+    }
+    result = await workflow.run(ApplicationState(profile=example_profile, auto_send=True))
+    pprint(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agent_suite/tests/conftest.py
+++ b/agent_suite/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration for Agent Suite."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/agent_suite/tests/test_workflow.py
+++ b/agent_suite/tests/test_workflow.py
@@ -1,0 +1,44 @@
+"""Unit tests for the application workflow."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_suite.workflows import ApplicationState, ApplicationWorkflow
+
+
+@pytest.mark.asyncio
+async def test_workflow_auto_send() -> None:
+    workflow = ApplicationWorkflow()
+    profile = {
+        "full_name": "Test Candidate",
+        "email": "test@example.com",
+        "education": ["B.Tech"],
+        "skills": ["Python", "FastAPI"],
+        "projects": [
+            {"name": "Project A", "description": "Desc", "impact": "Impact"},
+        ],
+        "interests": ["AI"],
+        "preferences": {"keywords": ["AI"], "remote": True},
+    }
+    result = await workflow.run(ApplicationState(profile=profile, auto_send=True))
+    assert result["review_status"] == "auto"
+    assert result["submissions"], "Expected submissions to be generated"
+    assert result["dashboard"], "Expected dashboard entries"
+
+
+@pytest.mark.asyncio
+async def test_workflow_requires_review() -> None:
+    workflow = ApplicationWorkflow()
+    profile = {
+        "full_name": "Review Candidate",
+        "email": "review@example.com",
+        "education": ["M.Tech"],
+        "skills": ["Research", "Python"],
+        "projects": [],
+        "interests": ["Research"],
+        "preferences": {"keywords": ["Research"], "remote": True},
+    }
+    result = await workflow.run(ApplicationState(profile=profile, auto_send=False))
+    assert result["review_status"] == "pending"
+    assert "submissions" not in result or not result["submissions"]


### PR DESCRIPTION
## Summary
- scaffold the Agent Suite package with LangGraph-based multi-agent workflow and supporting services
- add FastAPI backend, SQLAlchemy models, templates, and datasets for resume, cover letter, and job search automation
- provide documentation, example script, and pytest coverage for auto-send and human-review paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d149f490748322873cf802a0458788